### PR TITLE
Pylint alerts corrections as part of an intervention experiment 21 (src\stacosys\service\mail.py broad-exception-caught)

### DIFF
--- a/src/stacosys/service/mail.py
+++ b/src/stacosys/service/mail.py
@@ -3,7 +3,7 @@
 
 import logging
 from email.mime.text import MIMEText
-from smtplib import SMTP_SSL, SMTPAuthenticationError
+from smtplib import SMTP_SSL, SMTPAuthenticationError, SMTPException
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,6 @@ class Mailer:
 
                 server.send_message(msg)
             return True
-        except Exception:
+        except SMTPException:
             logger.error("Error sending email", exc_info=True)
         return False


### PR DESCRIPTION
Catching Exception might hide unexpected exceptions, like those that might be raised due to future modification. Therefore, it is recommended to narrow the exceptions.

The method send of the class Mailer catches Exception in line 57. MIMEText does not raise exceptions (if not using attachments). See
https://docs.python.org/3/library/email.mime.html

Most code is handled in an inner exception handling. In order to catch exception from SMTP_SSL I used SMTPException See
https://docs.python.org/3/library/smtplib.html

This is part of an intervention experiment that is described [here](https://github.com/evidencebp/pylint-intervention/).
[intervention issue](https://github.com/kianby/stacosys/issues/21).
